### PR TITLE
Abstract signing and sending of transaction out of account.

### DIFF
--- a/packages/core/src/BaseServiceClient.js
+++ b/packages/core/src/BaseServiceClient.js
@@ -60,7 +60,7 @@ class BaseServiceClient {
    * @returns {Promise<ChannelStateReply>}
    */
   async getChannelState(channelId) {
-    const signatureBytes = this._account.signedData({ t: 'uint256', v: channelId });
+    const signatureBytes = await this._account.signData({ t: 'uint256', v: channelId });
 
     const channelIdBytes = Buffer.alloc(4);
     channelIdBytes.writeUInt32BE(channelId, 0);
@@ -134,7 +134,7 @@ class BaseServiceClient {
     const signingAmount = lastSignedAmount.plus(this._pricePerServiceCall);
     logger.info(`Using PaymentChannel[id: ${channelId}] with nonce: ${nonce} and amount: ${signingAmount} and `, { tags: ['PaymentChannelManagementStrategy', 'gRPC'] });
 
-    const signatureBytes = this._account.signedData(
+    const signatureBytes = await this._account.signData(
       { t: 'address', v: this._mpeContract.address },
       { t: 'uint256', v: channelId },
       { t: 'uint256', v: nonce },

--- a/packages/core/src/identities/PrivateKeyIdentity.js
+++ b/packages/core/src/identities/PrivateKeyIdentity.js
@@ -1,0 +1,51 @@
+import Tx from 'ethereumjs-tx';
+import logger from '../utils/logger';
+
+class PrivateKeyIdentity {
+  constructor(config, web3) {
+    this._web3 = web3;
+    this._pk = config.privateKey;
+    this._setupAccount();
+  }
+
+  /**
+   * @type {string}
+   */
+  get address() {
+    return this._web3.eth.defaultAccount;
+  }
+
+  async signData(sha3Message) {
+    const { signature } = this._web3.eth.accounts.sign(sha3Message, this._pk);
+    return signature
+  }
+
+  async sendTransaction(transactionObject) {
+    const signedTransaction = this._signTransaction(transactionObject);
+    return new Promise((resolve, reject) => {
+      this._web3.eth.sendSignedTransaction(signedTransaction, (error, txHash) => {
+        if (error) {
+          logger.error(`Couldn't send transaction. ${error}`);
+          reject(error);
+        }
+        resolve(txHash);
+      });
+    });
+  }
+
+  _signTransaction(txObject) {
+    const transaction = new Tx(txObject);
+    const privateKey = Buffer.from(this._pk.slice(2), 'hex');
+    transaction.sign(privateKey);
+    const serializedTransaction = transaction.serialize();
+    return `0x${serializedTransaction.toString('hex')}`;
+  }
+
+  _setupAccount() {
+    const account = this._web3.eth.accounts.privateKeyToAccount(this._pk);
+    this._web3.eth.accounts.wallet.add(account);
+    this._web3.eth.defaultAccount = account.address;
+  }
+}
+
+export default PrivateKeyIdentity;

--- a/packages/core/src/identities/index.js
+++ b/packages/core/src/identities/index.js
@@ -1,0 +1,1 @@
+export { default as PrivateKeyIdentity } from './PrivateKeyIdentity';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -5,3 +5,4 @@ export { default as DefaultPaymentChannelManagementStrategy } from './payment_ch
 export { default as logger } from './utils/logger';
 export { default as BaseServiceClient} from './BaseServiceClient';
 export { default as PaymentChannel } from './PaymentChannel';
+export { PrivateKeyIdentity } from './identities';

--- a/packages/core/src/sdk.js
+++ b/packages/core/src/sdk.js
@@ -31,9 +31,9 @@ class SnetSDK {
     };
     this._networkId = config.networkId;
     this._web3 = new Web3(config.web3Provider, null, options);
+    const identity = this._createIdentity();
     this._mpeContract = new MPEContract(this._web3, this._networkId);
-    this._account = new Account(this._web3, this._networkId, this._config, this._mpeContract);
-    this._web3.eth.defaultAccount = this._account.address;
+    this._account = new Account(this._web3, this._networkId, this._mpeContract, identity);
     const registryAddress = RegistryNetworks[this._networkId].address;
     this._registryContract = new this._web3.eth.Contract(RegistryAbi, registryAddress, { from: this._account.address });
   }
@@ -94,6 +94,10 @@ class SnetSDK {
 
     logger.debug('PaymentChannelManagementStrategy not provided, using DefaultPaymentChannelManagementStrategy');
     return new DefaultPaymentChannelManagementStrategy(this);
+  }
+
+  _createIdentity() {
+    logger.error('_createIdentity must be implemented in the sub classes');
   }
 }
 

--- a/packages/nodejs/src/NodeSdk.js
+++ b/packages/nodejs/src/NodeSdk.js
@@ -1,5 +1,6 @@
 import SnetSDK from '../../core/src';
 import ServiceClient from './ServiceClient';
+import { PrivateKeyIdentity } from '../../core/src';
 
 class NodeSdk extends SnetSDK {
   /**
@@ -15,6 +16,10 @@ class NodeSdk extends SnetSDK {
     const serviceMetadata = await this.serviceMetadata(orgId, serviceId);
     const group = await this._serviceGroup(serviceMetadata, orgId, serviceId, groupName);
     return new ServiceClient(this, this._mpeContract, serviceMetadata, group, ServiceStub, this._constructStrategy(paymentChannelManagementStrategy), options);
+  }
+
+  _createIdentity() {
+    return new PrivateKeyIdentity(this._config, this._web3);
   }
 }
 


### PR DESCRIPTION
This allows us to keep account agnostic of the way signing and sending of transactions work. It could be PrivateKey based, offloaded to MetaMask or any other way.
At the moment we only support PrivateKeyIdentity.