### PR TITLE
Support for signer service

### DIFF
--- a/packages/core/src/BaseServiceClient.js
+++ b/packages/core/src/BaseServiceClient.js
@@ -177,7 +177,7 @@ class BaseServiceClient {
     logger.info(`Using PaymentChannel[id: ${channelIdStr}] with nonce: ${nonceStr} and amount: ${signingAmountStr} and `, { tags: ['PaymentChannelManagementStrategy', 'gRPC'] });
 
     if (this._options.paidCallMetadataGenerator) {
-      const { channelId, nonce, signingAmount, signatureBytes } = await this._options.paidCallMetadataGenerator(channelId, signingAmount, nonce);
+      const { signatureBytes } = await this._options.paidCallMetadataGenerator(channelId, signingAmount, nonce);
       return { channelId, nonce, signingAmount, signatureBytes };
     }
 

--- a/packages/core/src/BaseServiceClient.js
+++ b/packages/core/src/BaseServiceClient.js
@@ -176,6 +176,11 @@ class BaseServiceClient {
     const signingAmountStr = toBNString(signingAmount);
     logger.info(`Using PaymentChannel[id: ${channelIdStr}] with nonce: ${nonceStr} and amount: ${signingAmountStr} and `, { tags: ['PaymentChannelManagementStrategy', 'gRPC'] });
 
+    if (this._options.paidCallMetadataGenerator) {
+      const { channelId, nonce, signingAmount, signatureBytes } = await this._options.paidCallMetadataGenerator(channelId, signingAmount, nonce);
+      return { channelId, nonce, signingAmount, signatureBytes };
+    }
+
     const signatureBytes = await this._account.signData(
       { t: 'string', v: '__MPE_claim_message' },
       { t: 'address', v: this._mpeContract.address },

--- a/packages/core/src/BaseServiceClient.js
+++ b/packages/core/src/BaseServiceClient.js
@@ -135,7 +135,7 @@ class BaseServiceClient {
   }
 
   async _channelStateRequest(channelId) {
-    const { currentBlockNumber, signatureBytes } = this._channelStateRequestProperties(channelId);
+    const { currentBlockNumber, signatureBytes } = await this._channelStateRequestProperties(channelId);
     const channelIdBytes = Buffer.alloc(4);
     channelIdBytes.writeUInt32BE(channelId, 0);
 


### PR DESCRIPTION
We are using a signer service generating the signatures for making the state service calls as well as the service method invocation. This PR gives the sdk consumer a way to override the signature part. 